### PR TITLE
Split formatters into importer/exporter types

### DIFF
--- a/src/exporters/CsvExporter.php
+++ b/src/exporters/CsvExporter.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace fostercommerce\variantmanager\exporters;
+
+use craft\commerce\elements\Product;
+
+class CsvExporter extends Exporter
+{
+    public string $ext = 'csv';
+
+    public string $mimetype = 'text/csv';
+
+    // Read as "From" => "To"
+
+    public $variantHeadings = [
+        'SKU' => 'sku',
+        'Stock' => 'stock',
+        'Price' => 'price',
+        'Height' => 'height',
+        'Width' => 'width',
+        'Length' => 'length',
+        'Weight' => 'weight',
+        // TODO : Hard-coding these in for now, we should pull these from the plugins config file
+        'PART_NO' => 'mpn',
+        'CrossRef_Num' => 'crossReferenceNumber',
+    ];
+
+    public function normalizeVariantExport($variant, array $mapping = null): string
+    {
+        if ($mapping === null || $mapping === []) {
+            $mapping = $this->resolveVariantExportMapping($variant)[0];
+        }
+
+        $payload = [];
+
+        foreach ($mapping['variant'] as [$from, $to]) {
+            $payload[] = $variant->{$from};
+        }
+
+        foreach ($variant->variantAttributes as $attribute) {
+            $payload[] = $attribute['attributeValue'];
+        }
+
+        return implode(',', $payload);
+    }
+
+    public function resolveVariantExportMapping(&$product, $optionSignal = null): array
+    {
+        $optionSignal ??= 'Option : ';
+
+        $variantMap = [];
+        foreach (array_keys($this->variantHeadings) as $i => $heading) {
+            $variantMap[$i] = [$this->variantHeadings[$heading], $heading];
+        }
+
+        $optionMap = [];
+        foreach ($product->variants[0]->variantAttributes as $attribute) {
+            $optionMap[] = $optionSignal . $attribute['attributeName'];
+        }
+
+        return [
+            [
+                'variant' => $variantMap,
+                'option' => $optionMap,
+            ],
+            $optionSignal,
+        ];
+    }
+
+    protected function normalizeExportPayload(Product $product, array $variants): string
+    {
+        //if ($variants === null || !count($variants)) return null;
+
+        // TODO what is an optionSignal?
+        [$mapping, $optionSignal] = $this->resolveVariantExportMapping($product);
+
+        $payload = [
+            implode(',', array_merge(array_map(static fn($v) => $v[1], $mapping['variant']), $mapping['option'])),
+        ];
+        foreach ($variants as $variant) {
+            $payload[] = $this->normalizeVariantExport($variant, $mapping);
+        }
+
+        return implode("\n", $payload);
+    }
+}

--- a/src/exporters/Exporter.php
+++ b/src/exporters/Exporter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace fostercommerce\variantmanager\exporters;
+
+use craft\commerce\elements\Product;
+use craft\commerce\elements\Variant;
+
+abstract class Exporter
+{
+    public string $ext = 'txt';
+
+    public string $mimetype = 'text/plain';
+
+    public string $returnType = 'text/plain';
+
+    /**
+     * @throws \RuntimeException
+     */
+    public static function create(string $type = 'csv'): self
+    {
+        return match ($type) {
+            'csv' => new CsvExporter(),
+            'json' => new JsonExporter(),
+            default => throw new \RuntimeException('Invalid export type'),
+        };
+    }
+
+    /**
+     * @param Variant[] $variants
+     */
+    public function export(Product $product, array $variants)
+    {
+        return $this->normalizeExportPayload($product, $variants);
+    }
+
+    /**
+     * @param Variant[] $variants
+     */
+    abstract protected function normalizeExportPayload(Product $product, array $variants);
+}

--- a/src/exporters/JsonExporter.php
+++ b/src/exporters/JsonExporter.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace fostercommerce\variantmanager\helpers\formats;
+namespace fostercommerce\variantmanager\exporters;
 
 use craft\commerce\elements\Product;
-use craft\web\UploadedFile;
 
-class JSONFormat extends BaseFormat
+class JsonExporter extends Exporter
 {
     public string $ext = 'json';
 
@@ -34,11 +33,6 @@ class JSONFormat extends BaseFormat
         'mpn' => 'mpn',
         'crossReferenceNumber' => 'crossReferenceNumber',
     ];
-
-    public function read($file): never
-    {
-        throw new \RuntimeException('Importing using a JSON format has not been implemented yet.');
-    }
 
     public function resolveVariantExportMapping(&$variant): array
     {
@@ -80,11 +74,6 @@ class JSONFormat extends BaseFormat
         }
 
         return $payload;
-    }
-
-    protected function normalizeImportPayload(UploadedFile $uploadedFile): array
-    {
-        return [];
     }
 
     private function normalizeVariant($variant, array $mapping = null): array

--- a/src/importers/JsonImporter.php
+++ b/src/importers/JsonImporter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace fostercommerce\variantmanager\importers;
+
+use craft\web\UploadedFile;
+
+class JsonImporter extends Importer
+{
+    public string $ext = 'json';
+
+    public string $mimetype = 'application/json';
+
+    public string $returnType = 'application/json';
+
+    public array $variantHeadings = [
+        'id' => 'id',
+        'title' => 'title',
+        'sku' => 'sku',
+        'stock' => 'stock',
+        'minQty' => 'minQty',
+        'maxQty' => 'maxQty',
+        'onSale' => 'onSale',
+        'price' => 'price',
+        'priceAsCurrency' => 'priceAsCurrency',
+        'salePrice' => 'salePrice',
+        'salePriceAsCurrency' => 'salePriceAsCurrency',
+        'height' => 'height',
+        'width' => 'width',
+        'length' => 'length',
+        'weight' => 'weight',
+        'isAvailable' => 'isAvailable',
+        // TODO : Hard-coding these in for now, we should pull these from the plugins config file
+        'mpn' => 'mpn',
+        'crossReferenceNumber' => 'crossReferenceNumber',
+    ];
+
+    public function read($file): never
+    {
+        throw new \RuntimeException('Importing using a JSON format has not been implemented yet.');
+    }
+
+    protected function normalizeImportPayload(UploadedFile $uploadedFile): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
The CSVFormat and JSONFormat types are convoluted and complex. This PR breaks them up into classes for their individual purposes to start simplifying their logic.